### PR TITLE
Using the Authorization HTTP header

### DIFF
--- a/src/js/github_client.coffee
+++ b/src/js/github_client.coffee
@@ -1,11 +1,13 @@
 window.githubClient = {
   get: (url, options)->
     data = $.extend({}, options)
-    data.access_token = localStorage.accessToken
     return $.ajax {
       url: url,
       data: data,
-      type: 'GET'
+      type: 'GET',
+      headers: {
+        'Authorization': 'token ' + localStorage.accessToken
+      }
     }
   issues: (options)->
     githubClient.get (localStorage.endPoint || 'https://api.github.com/') + 'issues', $.extend({filter: 'assigned', state: 'open'}, options)


### PR DESCRIPTION
I always use this extension.
Thank you for the very good extension.

You will now receive a warning email from Github

```
Please use the Authorization HTTP header instead, as using the `access_token` query parameter is deprecated.
If this token is being used by an app you don't have control over, be aware that it may stop working as a result of this deprecation.
```

It seems that the specifications have changed due to the API update
https://developer.github.com/v3/#authentication

I changed it to use Authorization HTTP headers.

Sincerely.
Ryoji